### PR TITLE
Allow setting quick reply images

### DIFF
--- a/lib/hg/chunk.rb
+++ b/lib/hg/chunk.rb
@@ -302,6 +302,11 @@ module Hg
           title: title
         }
 
+        # If image_url is specified, include the asset path
+        if options[:image_url]
+          quick_reply_content[:image_url] = ApplicationController.helpers.image_url(options[:image_url])
+        end
+
         # If a `to` option is present, assume this is a postback link to another chunk.
         if options[:to]
           quick_reply_content[:payload] = JSON.generate({

--- a/lib/hg/chunk.rb
+++ b/lib/hg/chunk.rb
@@ -302,9 +302,13 @@ module Hg
           title: title
         }
 
-        # If image_url is specified, include the asset path
+        # If image_url is specified include the url or asset path
         if options[:image_url]
-          quick_reply_content[:image_url] = ApplicationController.helpers.image_url(options[:image_url])
+          if options.has_key?(:host)
+            quick_reply_content[:image_url] = ApplicationController.helpers.image_url(options[:image_url], host: options[:host])
+          else
+            quick_reply_content[:image_url] = options[:image_url]
+          end
         end
 
         # If a `to` option is present, assume this is a postback link to another chunk.


### PR DESCRIPTION
Allows for a Messenger quick reply to have a custom image via local asset, URL, or Messenger's Attachment Upload API

Requires `ENV['HOSTNAME']` for local assets

External URL or Attachment API URL:
```
quick_reply 'Red Circle', {
  payload: { action: MessengerBot::Actions::RED_CIRCLE },
  image_url: 'http://example.com/img/red.png'
}
```
Local image asset:
```
quick_reply 'Red Circle', {
  payload: {
    action: MessengerBot::Actions::RED_CIRCLE
  },
  image_url: 'circles/red-circle.png',
  host: ENV['HOSTNAME']
}
```