### PR TITLE
Add varying text method to Chunk

### DIFF
--- a/lib/hg/chunk.rb
+++ b/lib/hg/chunk.rb
@@ -121,6 +121,17 @@ module Hg
           }
       end
 
+      # Method to handle text variation in chunk
+      #
+      # @param [Array] samples
+      #   Array of various strings to add to chunk
+      #
+      # @return [void]
+      def varying_text(samples)
+        # Sample array
+        text samples.sample
+      end
+
       def title(text)
         @card[:title] = text
       end


### PR DESCRIPTION
Added a method to sample an array of strings for copy variation in a chunk.

Usage:
```
module Chunks
  class SomeChunk

    MENU_RESPONSES = [
      'Here’s a message',
      'And another'
    ].freeze

    varying_text MENU_RESPONSES   #=> text 'And another'
...
```