### PR TITLE
Add support for arrays in text method

### DIFF
--- a/app/workers/hg/message_worker.rb
+++ b/app/workers/hg/message_worker.rb
@@ -98,7 +98,7 @@ module Hg
           # Set chatbase fields and determine not_handled
           if ENV['CHATBASE_API_KEY']
             @not_handled = false
-            if nlu_response.intent.nil? || request.intent == 'Default'
+            if !nlu_response[:intent] || request.intent == 'Default'
               @not_handled = true
             else
               set_chatbase_fields(request.intent, message.text, @not_handled)

--- a/lib/hg/chunk.rb
+++ b/lib/hg/chunk.rb
@@ -112,7 +112,16 @@ module Hg
         }, access_token: ENV['FB_ACCESS_TOKEN'])
       end
 
+      # Add text message to chunk
+      #
+      # @param [String, Array] message
+      #   Message to be delivered.
+      #   If message is an array, will deliver one at random
+      #
+      # @return [void]
       def text(message)
+        # Sample if message is an array
+        message = message.sample if message.respond_to?(:sample)
         @deliverables <<
           {
             message: {


### PR DESCRIPTION
Added a method to sample an array of strings for copy variation in a chunk.
Also added Chatbase fix present in ABBY-2018 branch

Usage:
```
...
MENU_RESPONSES = [
  'Here’s a message',
  'And another'
].freeze

text MENU_RESPONSES   #=> 'And another'
...
```